### PR TITLE
Feat/telementry  app name crp

### DIFF
--- a/media/queryEditor.css
+++ b/media/queryEditor.css
@@ -8417,4 +8417,59 @@
 		.results-tools-dropdown-menu.show-visibility-item .results-tools-dropdown-sep.results-visibility-item {
 			display: block;
 		}
+
+		/* ── Results footer (Client Activity ID) ── */
+		.results-footer {
+			display: flex;
+			align-items: center;
+			gap: 6px;
+			padding: 3px 8px;
+			font-size: 11px;
+			color: var(--vscode-descriptionForeground, #888);
+			border-top: 1px solid var(--vscode-widget-border, rgba(128, 128, 128, 0.2));
+			flex-shrink: 0;
+			min-height: 22px;
+			user-select: text;
+		}
+
+		.results-footer-label {
+			white-space: nowrap;
+			font-weight: 500;
+		}
+
+		.results-footer-value {
+			font-family: var(--vscode-editor-font-family, monospace);
+			font-size: 11px;
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			min-width: 0;
+		}
+
+		.results-footer-copy-btn {
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			background: transparent;
+			border: none;
+			color: var(--vscode-descriptionForeground, #888);
+			cursor: pointer;
+			padding: 1px 3px;
+			border-radius: 3px;
+			flex-shrink: 0;
+		}
+
+		.results-footer-copy-btn:hover {
+			color: var(--vscode-foreground);
+			background: var(--vscode-toolbar-hoverBackground, rgba(128, 128, 128, 0.15));
+		}
+
+		.results-footer-copy-btn svg {
+			width: 13px;
+			height: 13px;
+		}
+
+		.results-footer-copy-btn.results-footer-copy-done {
+			color: var(--vscode-terminal-ansiGreen, #89d185);
+		}
 	

--- a/media/queryEditor/resultsTable.js
+++ b/media/queryEditor/resultsTable.js
@@ -1,3 +1,20 @@
+function __kustoCopyClientActivityId(boxId) {
+	try {
+		const el = document.getElementById(boxId + '_client_activity_id');
+		const text = el ? el.textContent : '';
+		if (text && navigator.clipboard) {
+			navigator.clipboard.writeText(text).then(function () {
+				// Brief visual feedback
+				const btn = el && el.nextElementSibling;
+				if (btn) {
+					btn.classList.add('results-footer-copy-done');
+					setTimeout(function () { btn.classList.remove('results-footer-copy-done'); }, 1200);
+				}
+			}).catch(function () { /* ignore */ });
+		}
+	} catch { /* ignore */ }
+}
+
 function __kustoGetSearchIconSvg() {
 	return (
 		'<svg viewBox="0 0 16 16" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">' +
@@ -2815,6 +2832,17 @@ function displayResultForBox(result, boxId, options) {
 		'</div>' +
 		'</div>';
 
+	const clientActivityId = metadata && typeof metadata.clientActivityId === 'string' ? metadata.clientActivityId : '';
+	const clientActivityIdHtml = clientActivityId
+		? '<div class="results-footer" id="' + boxId + '_results_footer">' +
+		  '<span class="results-footer-label">Client Activity ID:</span>' +
+		  '<span class="results-footer-value" id="' + boxId + '_client_activity_id" title="' + clientActivityId + '">' + clientActivityId + '</span>' +
+		  '<button class="results-footer-copy-btn" type="button" onclick="__kustoCopyClientActivityId(\'' + __kustoEscapeJsStringLiteral(boxId) + '\')" title="Copy to clipboard" aria-label="Copy Client Activity ID">' +
+		  copyIconSvg +
+		  '</button>' +
+		  '</div>'
+		: '';
+
 	let html =
 		'<div class="results-header">' +
 		'<div class="results-title-row">' +
@@ -2878,6 +2906,7 @@ function displayResultForBox(result, boxId, options) {
 		'</table>' +
 		'</div>' +
 		'</div>' +
+		clientActivityIdHtml +
 		'<div class="kusto-sort-modal" id="' + boxId + '_sort_modal" onclick="closeSortDialogOnBackdrop(event, \'' + __kustoEscapeJsStringLiteral(boxId) + '\')">' +
 		'<div class="kusto-sort-dialog" onclick="event.stopPropagation();">' +
 		'<div class="kusto-sort-header">' +

--- a/src/kustoClient.ts
+++ b/src/kustoClient.ts
@@ -9,6 +9,7 @@ export interface QueryResult {
 		cluster: string;
 		database: string;
 		executionTime: string;
+		clientActivityId?: string;
 	};
 }
 
@@ -150,6 +151,31 @@ export class KustoQueryClient {
 		props.clientRequestId = `KW.${activityPrefix};${randomUUID()}`;
 		props.application = KustoQueryClient.APPLICATION_NAME;
 		return props;
+	}
+
+	/**
+	 * Extracts the Client Activity ID from a Kusto response's status table.
+	 * Works with both V1 (column: `ClientActivityId`) and V2 (column: `ClientRequestId`) responses.
+	 */
+	private extractClientActivityId(result: any): string | undefined {
+		try {
+			const statusTable = result?.statusTable;
+			if (!statusTable || !statusTable._rows || statusTable._rows.length === 0) {
+				return undefined;
+			}
+			// The response object exposes getCridColumn() which returns the correct column name
+			// for the protocol version (V1: "ClientActivityId", V2: "ClientRequestId").
+			// However, we access the result generically, so try both column names.
+			for (const row of statusTable.rows()) {
+				const id = row?.['ClientActivityId'] ?? row?.['ClientRequestId'];
+				if (typeof id === 'string' && id.trim()) {
+					return id.trim();
+				}
+			}
+		} catch {
+			// Extraction is best-effort; never let it break query execution.
+		}
+		return undefined;
 	}
 
 	private syncCacheClearEpoch(): void {
@@ -791,6 +817,7 @@ export class KustoQueryClient {
 			const props = await this.createRequestProperties('execute_query');
 			const result = await this.executeWithAuthRetry<any>(connection, (client) => client.execute(database, query, props));
 			const executionTime = ((Date.now() - startTime) / 1000).toFixed(3) + 's';
+			const clientActivityId = this.extractClientActivityId(result);
 			
 			// Get the primary result
 			const primaryResults = result.primaryResults[0];
@@ -882,7 +909,8 @@ export class KustoQueryClient {
 				metadata: {
 					cluster: connection.clusterUrl,
 					database: database,
-					executionTime
+					executionTime,
+					clientActivityId
 				}
 			};
 		} catch (error) {
@@ -947,6 +975,7 @@ export class KustoQueryClient {
 					{ allowInteractive: true, cancelableKey: key, onClient: (c2) => { client = c2; } }
 				);
 				const executionTime = ((Date.now() - startTime) / 1000).toFixed(3) + 's';
+				const clientActivityId = this.extractClientActivityId(result);
 
 				const primaryResults = result.primaryResults[0];
 				const columns = primaryResults.columns.map((col: any) => col.name || col.type || 'Unknown');
@@ -1012,7 +1041,8 @@ export class KustoQueryClient {
 					metadata: {
 						cluster: connection.clusterUrl,
 						database: database,
-						executionTime
+						executionTime,
+						clientActivityId
 					}
 				};
 			} catch (error) {

--- a/src/kustoClient.ts
+++ b/src/kustoClient.ts
@@ -1,4 +1,5 @@
 import { KustoConnection } from './connectionManager';
+import { randomUUID } from 'crypto';
 import * as vscode from 'vscode';
 
 export interface QueryResult {
@@ -137,6 +138,20 @@ export class KustoQueryClient {
 		this.context = context;
 	}
 
+	private static readonly APPLICATION_NAME = 'KustoWorkbench';
+
+	/**
+	 * Creates a {@link ClientRequestProperties} with the `Application` and `ClientActivityId` headers set.
+	 * @param activityPrefix Short label for the operation, e.g. `execute_query` or `get_databases`.
+	 */
+	private async createRequestProperties(activityPrefix: string): Promise<any> {
+		const { ClientRequestProperties } = await import('azure-kusto-data');
+		const props = new ClientRequestProperties();
+		props.clientRequestId = `KW.${activityPrefix};${randomUUID()}`;
+		props.application = KustoQueryClient.APPLICATION_NAME;
+		return props;
+	}
+
 	private syncCacheClearEpoch(): void {
 		if (!this.context) {
 			return;
@@ -269,6 +284,7 @@ export class KustoQueryClient {
 		const { Client, KustoConnectionStringBuilder } = await import('azure-kusto-data');
 		const effectiveToken = await this.getEffectiveAccessToken(session);
 		const kcsb = KustoConnectionStringBuilder.withAccessToken(clusterEndpoint, effectiveToken);
+		kcsb.applicationNameForTracing = KustoQueryClient.APPLICATION_NAME;
 		return { client: new Client(kcsb), clusterEndpoint, accountId };
 	}
 
@@ -581,6 +597,7 @@ export class KustoQueryClient {
 			const { Client, KustoConnectionStringBuilder } = await import('azure-kusto-data');
 			const effectiveToken = await this.getEffectiveAccessToken(session);
 			const kcsb = KustoConnectionStringBuilder.withAccessToken(clusterEndpoint2, effectiveToken);
+			kcsb.applicationNameForTracing = KustoQueryClient.APPLICATION_NAME;
 			const entry: CachedClientEntry = { client: new Client(kcsb), clusterEndpoint: clusterEndpoint2, accountId };
 			if (storeInMain) {
 				this.clients.set(connection.id, entry);
@@ -645,6 +662,7 @@ export class KustoQueryClient {
 					const { Client, KustoConnectionStringBuilder } = await import('azure-kusto-data');
 					const effectiveToken = await this.getEffectiveAccessToken(session);
 					const kcsb = KustoConnectionStringBuilder.withAccessToken(clusterEndpoint, effectiveToken);
+					kcsb.applicationNameForTracing = KustoQueryClient.APPLICATION_NAME;
 					const client = new Client(kcsb);
 					await this.setClusterAccountId(clusterEndpoint, session.account.id);
 					await this.upsertKnownAccount(session.account);
@@ -729,9 +747,10 @@ export class KustoQueryClient {
 				}
 			}
 
+			const props = await this.createRequestProperties('get_databases');
 			const result = await this.executeWithAuthRetry<any>(
 				connection,
-				(client) => client.execute('', '.show databases'),
+				(client) => client.execute('', '.show databases', props),
 				{ allowInteractive: opts?.allowInteractive }
 			);
 			
@@ -769,7 +788,8 @@ export class KustoQueryClient {
 		const startTime = Date.now();
 		
 		try {
-			const result = await this.executeWithAuthRetry<any>(connection, (client) => client.execute(database, query));
+			const props = await this.createRequestProperties('execute_query');
+			const result = await this.executeWithAuthRetry<any>(connection, (client) => client.execute(database, query, props));
 			const executionTime = ((Date.now() - startTime) / 1000).toFixed(3) + 's';
 			
 			// Get the primary result
@@ -920,9 +940,10 @@ export class KustoQueryClient {
 				if (cancelled) {
 					throw new QueryCancelledError();
 				}
+				const props = await this.createRequestProperties('execute_query');
 				const result = await this.executeWithAuthRetry<any>(
 					connection,
-					(c) => c.execute(database, query),
+					(c) => c.execute(database, query, props),
 					{ allowInteractive: true, cancelableKey: key, onClient: (c2) => { client = c2; } }
 				);
 				const executionTime = ((Date.now() - startTime) / 1000).toFixed(3) + 's';
@@ -1050,7 +1071,8 @@ export class KustoQueryClient {
 		let lastError: unknown = null;
 		for (const command of tryCommands) {
 			try {
-				const result = await this.executeWithAuthRetry<any>(connection, (client) => client.execute(database, command));
+				const props = await this.createRequestProperties('get_schema');
+				const result = await this.executeWithAuthRetry<any>(connection, (client) => client.execute(database, command, props));
 				const debug = this.buildSchemaDebug(result, command);
 				const { schema, rawSchemaJson } = this.parseDatabaseSchemaResultWithRaw(result, command);
 


### PR DESCRIPTION
This pull request introduces support for displaying and copying the Client Activity ID for Kusto queries in the results UI, and ensures that all Kusto requests are properly tagged with application and activity metadata. The changes improve traceability and user experience by surfacing the Client Activity ID in the results and allowing users to copy it easily for diagnostics or support.